### PR TITLE
[APIS-758] PDO Driver Update for PHP version 7 and CUBRID 10.1.0

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -37,6 +37,10 @@ if test "$PHP_PDO_CUBRID" != "no"; then
             chmod +x configure
             chmod +x external/libregex38a/configure
             chmod +x external/libregex38a/install-sh
+			chmod +x autogen.sh
+			chmod +x build.sh
+			./autogen.sh
+			./build.sh -t 64
             ./configure --enable-64bit
     	    make
             popd
@@ -46,6 +50,10 @@ if test "$PHP_PDO_CUBRID" != "no"; then
             chmod +x configure
             chmod +x external/libregex38a/configure
             chmod +x external/libregex38a/install-sh
+			chmod +x autogen.sh
+			chmod +x build.sh
+			./autogen.sh
+			./build.sh -t 32
             ./configure
     	    make
             popd

--- a/cubrid_driver.c
+++ b/cubrid_driver.c
@@ -343,14 +343,13 @@ static int cubrid_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, int unquot
 	
 	*quoted = (char *) emalloc(2 * unquotedlen + 18);
 
-	if ((ret = cci_escape_string(H->conn_handle, *quoted+1, unquoted, unquotedlen, &error)) < 0) {
+	if ((ret = cci_escape_string(H->conn_handle, *quoted, unquoted, unquotedlen, &error)) < 0) {
 		pdo_cubrid_error(dbh, ret, &error, NULL);
 		efree(*quoted);
 		return 0;
 	}
 	*quotedlen = ret;
-	(*quoted)[0] =(*quoted)[++*quotedlen] = '\'';	
-	(*quoted)[++*quotedlen] = '\0';
+	(*quoted)[*quotedlen] = '\0';
 
 	return 1;
 }
@@ -760,12 +759,12 @@ static int pdo_cubrid_handle_factory(pdo_dbh_t *dbh, zval *driver_options TSRMLS
 	int i;
 
     char *host = NULL, *dbname = NULL;
-    unsigned int port = 33000;
+    unsigned int port = 55300;
 
     struct pdo_data_src_parser vars[] = {
 		{ "host", "localhost", 0 },
-		{ "port", "33000", 0},
-		{ "dbname", "", 0 }
+		{ "port", "55300", 0},
+		{ "dbname", "demodb", 0 }
     };
 
 	char connect_url[2048] = {'\0'};

--- a/cubrid_driver7.c
+++ b/cubrid_driver7.c
@@ -333,8 +333,8 @@ static long cubrid_handle_doer(pdo_dbh_t *dbh, const char *sql, long sql_len TSR
 	return ret;
 }
 
-static int cubrid_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, int unquotedlen, 
-		char **quoted, int *quotedlen, enum pdo_param_type paramtype TSRMLS_DC)
+static int cubrid_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unquotedlen, 
+		char **quoted, size_t *quotedlen, enum pdo_param_type paramtype TSRMLS_DC)
 {
 	pdo_cubrid_db_handle *H = (pdo_cubrid_db_handle *)dbh->driver_data;
 
@@ -343,14 +343,14 @@ static int cubrid_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, int unquot
 	
 	*quoted = (char *) emalloc(2 * unquotedlen + 18);
 
-	if ((ret = cci_escape_string(H->conn_handle, *quoted+1, unquoted, unquotedlen, &error)) < 0) {
+	if ((ret = cci_escape_string(H->conn_handle, *quoted, unquoted, unquotedlen, &error)) < 0) {
 		pdo_cubrid_error(dbh, ret, &error, NULL);
 		efree(*quoted);
 		return 0;
 	}
 	*quotedlen = ret;
-	(*quoted)[0] =(*quoted)[++*quotedlen] = '\'';	
-	(*quoted)[++*quotedlen] = '\0';
+	//(*quoted)[0] =(*quoted)[++*quotedlen] = '\'';	
+	(*quoted)[*quotedlen] = '\0';
 
 	return 1;
 }
@@ -561,7 +561,7 @@ static int pdo_cubrid_get_attribute(pdo_dbh_t *dbh, long attr, zval *return_valu
 	return 1;
 }
 
-static char *pdo_cubrid_last_insert_id(pdo_dbh_t *dbh, const char *name, unsigned int *len TSRMLS_DC)
+static char *pdo_cubrid_last_insert_id(pdo_dbh_t *dbh, const char *name, size_t *len TSRMLS_DC)
 {
 	pdo_cubrid_db_handle *H = (pdo_cubrid_db_handle *)dbh->driver_data;
 
@@ -636,7 +636,9 @@ static PHP_METHOD(PDO, cubrid_schema)
 	pdo_cubrid_db_handle *H;
 
     char *class_name = NULL, *attr_name = NULL;
-    long schema_type, class_name_len, attr_name_len;
+    //long schema_type, class_name_len, attr_name_len;
+    zend_long schema_type;
+	size_t class_name_len, attr_name_len;
 
     int request_handle;
     int flag = 0;
@@ -665,7 +667,7 @@ static PHP_METHOD(PDO, cubrid_schema)
 		break;
     }
 
-	dbh = Z_OBJ_P(getThis() TSRMLS_CC);
+	dbh = Z_PDO_DBH_P(getThis() TSRMLS_CC);
 	PDO_CONSTRUCT_CHECK;
 
 	H = (pdo_cubrid_db_handle *)dbh->driver_data;
@@ -757,12 +759,12 @@ static int pdo_cubrid_handle_factory(pdo_dbh_t *dbh, zval *driver_options TSRMLS
 	int i;
 
     char *host = NULL, *dbname = NULL;
-    unsigned int port = 33000;
+    unsigned int port = 55300;
 
     struct pdo_data_src_parser vars[] = {
 		{ "host", "localhost", 0 },
-		{ "port", "33000", 0},
-		{ "dbname", "", 0 }
+		{ "port", "55300", 0},
+		{ "dbname", "demodb", 0 }
     };
 
 	char connect_url[2048] = {'\0'};

--- a/package.xml
+++ b/package.xml
@@ -10,11 +10,11 @@
   <email>esen.sagynov@nhn.com</email>
   <active>yes</active>
  </lead>
- <date>2014-05-15</date>
- <time>11:38:49</time>
+ <date>2017-08-07</date>
+ <time>17:10:00</time>
  <version>
-  <release>9.3.0.0001</release>
-  <api>9.3.0</api>
+  <release>10.1.0.0001</release>
+  <api>10.1.0</api>
  </version>
  <stability>
   <release>stable</release>
@@ -22,203 +22,207 @@
  </stability>
  <license uri="http://www.php.net/license">PHP</license>
  <notes>
-  Support cubrid engine version up to 9.3
+  1) Support cubrid engine version up to 10.1.0
+  2) Support PHP version 7 (7.1.x)
  </notes>
  <contents>
   <dir name="/">
 
-<file md5sum="6314d6d46309c8140fa8e99a1e3ac893" name="config.w32" role="src" />
-<file md5sum="db5ddf8bda62a7f61f8466d43550b1d6" name="config.m4" role="src" />
-<file md5sum="a935e105cd60e4d877475173130c9e3a" name="CREDITS" role="src" />
-<file md5sum="9f08c8ef168fe7dc12f31dabc2ecf0b3" name="win/VC11/pdo_cubrid.vcxproj" role="src" />
-<file md5sum="4a2e5738c9f40ee80a5cf0980a04d890" name="win/VC11/pdo_cubrid.sln" role="src" />
-<file md5sum="bff1e1f22b205ccc6b3e8062c27d922c" name="win/pdo_cubrid.sln" role="src" />
-<file md5sum="78e7b5a3070db026079720233d0c0c20" name="win/pdo_cubrid.vcproj" role="src" />
-<file md5sum="6cffe2c4328dc45439d42a3a036ef986" name="pdo_cubrid.c" role="src" />
-<file md5sum="d6c3f811c6d63056db0280b4e475e0dd" name="tests/bug_36428.phpt" role="src" />
-<file md5sum="b73ae7969067216f9cbeb00c7713d003" name="tests/pdo_025.phpt" role="src" />
-<file md5sum="4edca8085a58d1dd93e05bb1772f8163" name="tests/bug_36798.phpt" role="src" />
-<file md5sum="2789968fdfc6f82178ad78359852b165" name="tests/bug47769.phpt" role="src" />
-<file md5sum="84f21d61e2eb25e5afbb9f8d47d1fc4c" name="tests/pdo_001.phpt" role="src" />
-<file md5sum="1c420de065534fc8050ad3ef25e64d07" name="tests/pdo_023.phpt" role="src" />
-<file md5sum="d6aebc1a31ec583cf69d0e01dfc507ec" name="tests/pdo_034.phpt" role="src" />
-<file md5sum="299ded8cd8cd190be05e48c938d99238" name="tests/pdo.inc" role="src" />
-<file md5sum="374b14b547d5e15c605604f7bf7a6d25" name="tests/pdo_028.phpt" role="src" />
-<file md5sum="bafe1df2ac507aa940d46ba61054ad15" name="tests/pdo_038.phpt" role="src" />
-<file md5sum="a49fe85093db420c0ee14ee33ea0d534" name="tests/bug_50458.phpt" role="src" />
-<file md5sum="849619bb6f1f34a31037ab402e829990" name="tests/pdo_018.phpt" role="src" />
-<file md5sum="4039506d01c8a589cea02a7d4b0107fd" name="tests/pdo_003.phpt" role="src" />
-<file md5sum="65e8af31168eb3d77d0ce2c2ac715be9" name="tests/bug_43663.phpt" role="src" />
-<file md5sum="1695421f2c2973d8eb619e04b2b13013" name="tests/pdo_004.phpt" role="src" />
-<file md5sum="b7e38364a40f61c25d08235605b09bfd" name="tests/pdo_016a.phpt" role="src" />
-<file md5sum="4788a65358f67895f9868ba3292266ef" name="tests/bug_40285.phpt" role="src" />
-<file md5sum="99b3b6a83514ac45cdea1465e144233a" name="tests/pdo_027.phpt" role="src" />
-<file md5sum="32c53bb19a3c103b9769e1b0c680bbcd" name="tests/pdo_039.phpt" role="src" />
-<file md5sum="2fc10825b8d14aebfaacee133e28ee76" name="tests/bug_39398.phpt" role="src" />
-<file md5sum="f8166582f6f9810424e315160829b1ba" name="tests/pdo_014.phpt" role="src" />
-<file md5sum="8faceff062e2d45a12a827c0336e65f5" name="tests/bug_44159.phpt" role="src" />
-<file md5sum="28c6882380e4deaf0ee5fbb91865ce2e" name="tests/pdo_041.phpt" role="src" />
-<file md5sum="8005d489b47db3887be78bd106bdb9fb" name="tests/pdo_enum.phpt" role="src" />
-<file md5sum="2d541269a06b003690b4261aff0fe47c" name="tests/bug_43139.phpt" role="src" />
-<file md5sum="4f96a2df245d753650f73060e0ce2b9d" name="tests/pecl_bug_5772.phpt" role="src" />
-<file md5sum="d48416e620231014a5d5033eff684aba" name="tests/pdo_020.phpt" role="src" />
-<file md5sum="b1833a8f23c25e39a232733a06329781" name="tests/pdo_029.phpt" role="src" />
-<file md5sum="c0d9a4a6f54e3559fa9ed55c86adb5da" name="tests/bug_44409.phpt" role="src" />
-<file md5sum="64d8d4649951fd6e4e5120a3baa7190e" name="tests/bug_39656.phpt" role="src" />
-<file md5sum="7c5cb8740f633def8763c14e546b4853" name="tests/bug_38394.phpt" role="src" />
-<file md5sum="b751e9cffa0ead308dce3b0e12920f46" name="tests/pdo_007.phpt" role="src" />
-<file md5sum="0bd7f2b61ff102825f76cfce2d600add" name="tests/pdo_002.phpt" role="src" />
-<file md5sum="623f028876cb0ce4243e2a53cf6bbf5d" name="tests/bug_42917.phpt" role="src" />
-<file md5sum="76ba2f4972b9eec63f3d31eea144813d" name="tests/pdo_009.phpt" role="src" />
-<file md5sum="c660ccad20fb2613b23ca52ee31d2e14" name="tests/pecl_bug_5217.phpt" role="src" />
-<file md5sum="69b9d89762dbc0c2a97eb59a86ca0c08" name="tests/bug_34687.phpt" role="src" />
-<file md5sum="eb0478e853991cf398b2173f2c3fd18f" name="tests/pdo_010.phpt" role="src" />
-<file md5sum="4d20061022408bece038d6b3825e4cd6" name="tests/pdo_013.phpt" role="src" />
-<file md5sum="6a89364d293a25e43fb39c2b98db65f4" name="tests/pdo_033.phpt" role="src" />
-<file md5sum="4c0d75db2444cbb361428dce3fbdffb4" name="tests/pdo_011.phpt" role="src" />
-<file md5sum="ff0b9f453c79a0a54a36111366cddf72" name="tests/pdo_037.phpt" role="src" />
-<file md5sum="829a8e78b9e220091094ef5370c46bd9" name="tests/pdo_032.phpt" role="src" />
-<file md5sum="5b0b8bd9c177a9706c5a5fdfb012fb8f" name="tests/pdo_015.phpt" role="src" />
-<file md5sum="4d550c894ce5ed50722d956a3dbdaa12" name="tests/pdo_012.phpt" role="src" />
-<file md5sum="dbf5f36dca365bbd0f2e34b3db6f2441" name="tests/pdo_036.phpt" role="src" />
-<file md5sum="f481181bcf3adceec16c963a29a55865" name="tests/pdo_019.phpt" role="src" />
-<file md5sum="083a4d862a5ac7710fbf5ecab6eb64b4" name="tests/pdorow.phpt" role="src" />
-<file md5sum="44c6d2de995cdcaf1878a5e589668868" name="tests/pdo_022.phpt" role="src" />
-<file md5sum="c5bd7ee9a5f599e9d65c1942ec2cd8e9" name="tests/pecl_bug_5809.phpt" role="src" />
-<file md5sum="fc8ec40d9134bc2283ebb471eecc85b0" name="tests/bug_44173.phpt" role="src" />
-<file md5sum="a97d7761c95f6a8904b46f44cbe1ba92" name="tests/bug_44861.phpt" role="src" />
-<file md5sum="94942ca84502cba9bd0b6895f6b57dfa" name="tests/pdo_test.inc" role="src" />
-<file md5sum="0e0f9f03be1cc0810fac8e5f077e4460" name="tests/bug_38253.phpt" role="src" />
-<file md5sum="6788938fd607c9d9553bc6205902f1fd" name="tests/pdo_017.phpt" role="src" />
-<file md5sum="9fcdbbc7c54f6fb9fc41a3ad69cde22f" name="tests/pdo_031.phpt" role="src" />
-<file md5sum="3674bde5fd0f92885905eb04c172d504" name="tests/pdo_cubrid_stmt_getcolumnmeta.phpt" role="src" />
-<file md5sum="1a3c7b3beaec6d37358295526a67000c" name="tests/bug_35671.phpt" role="src" />
-<file md5sum="1dcadc4e774431735dc68aae17d7a1cc" name="tests/pdo_035.phpt" role="src" />
-<file md5sum="c0feff0512072c70326060d8fc27b1c3" name="tests/run-tests.php" role="src" />
-<file md5sum="e3b8b11c3bb0a2673ee8e27daa853ccb" name="tests/pdo_008.phpt" role="src" />
-<file md5sum="18db924a2b76e3bc3ae329066147ea25" name="tests/pdo_021.phpt" role="src" />
-<file md5sum="cefab224adc600103fced88002c158b2" name="tests/pdo_024.phpt" role="src" />
-<file md5sum="4d686b69dcb4a5cd75e42cdc90df945d" name="tests/pdo_026.phpt" role="src" />
-<file md5sum="0c45753f340620ad2b713ca60d4c8f20" name="tests/pdo_040.phpt" role="src" />
-<file md5sum="1b8742d9b0171148d668fdbd217b2339" name="tests/pdo_030.phpt" role="src" />
-<file md5sum="cbb918775f0f5c4cdf6cda03ca161997" name="tests/pdo_006.phpt" role="src" />
-<file md5sum="6c19812242bda41f706b3b58e44138d6" name="tests/pdo_005.phpt" role="src" />
-<file md5sum="b859a93642afe59b9dba43eaf4c245e8" name="tests/pdo_016.phpt" role="src" />
-<file md5sum="b915dd0dea7642d07042ff94ae258119" name="tests/bug_34630.phpt" role="src" />
-<file md5sum="7a6d236beb2429915af9797dd6d703bb" name="README" role="src" />
-<file md5sum="0554d992d1031a5ae6d80e3688b95b1e" name="cci-src/autogen.sh" role="src" />
-<file md5sum="fd94792c7c6dfa41e90815ea79e3277e" name="cci-src/configure.ac" role="src" />
-<file md5sum="3a05fb504a9d1b0b39fbc210bf306870" name="cci-src/configure" role="src" />
-<file md5sum="c59873d5e77d60f8d2eabece67279ba5" name="cci-src/build.sh" role="src" />
-<file md5sum="ee3a31b065e440511f80d9f439383a75" name="cci-src/aclocal.m4" role="src" />
-<file md5sum="64647b3151b5131f36a78160acf17104" name="cci-src/external/libregex38a/configure.ac" role="src" />
-<file md5sum="3b14816e33e02a04aa4b7e07684c0c81" name="cci-src/external/libregex38a/regerror.c" role="src" />
-<file md5sum="67fb692ba29f2df34ddf3d3cfd7e2962" name="cci-src/external/libregex38a/configure.gnu" role="src" />
-<file md5sum="7fc030a85a8f3d4864a65db5fb70c794" name="cci-src/external/libregex38a/config.guess" role="src" />
-<file md5sum="ad94b91bb05c50055e46d1cd33d79b97" name="cci-src/external/libregex38a/configure" role="src" />
-<file md5sum="d41d8cd98f00b204e9800998ecf8427e" name="cci-src/external/libregex38a/NEWS" role="src" />
-<file md5sum="98411fe29b7b47bde018efc6097c64af" name="cci-src/external/libregex38a/regexec.c" role="src" />
-<file md5sum="2a462a9971a32186b9d1e1a13f956154" name="cci-src/external/libregex38a/aclocal.m4" role="src" />
-<file md5sum="5bb92a4351b53c9d5bd997f80a8169d3" name="cci-src/external/libregex38a/cclass.h" role="src" />
-<file md5sum="6b15e29933ad151d95018519d6fb8abd" name="cci-src/external/libregex38a/config.h.in" role="src" />
-<file md5sum="d41d8cd98f00b204e9800998ecf8427e" name="cci-src/external/libregex38a/AUTHORS" role="src" />
-<file md5sum="9529709b5474f9d58eb3a3c7b82edc02" name="cci-src/external/libregex38a/Makefile.in" role="src" />
-<file md5sum="ac4d4c0503bbe22d26fda8787918af2f" name="cci-src/external/libregex38a/include/regex38a.h" role="src" />
-<file md5sum="82397056d6a780f8f67137995ff86f2a" name="cci-src/external/libregex38a/include/Makefile.in" role="src" />
-<file md5sum="b4804b8b1f754a46007247dae6cce52c" name="cci-src/external/libregex38a/include/Makefile.am" role="src" />
-<file md5sum="d41d8cd98f00b204e9800998ecf8427e" name="cci-src/external/libregex38a/INSTALL" role="src" />
-<file md5sum="aded5875c5d5830de6653181e8ced19c" name="cci-src/external/libregex38a/install-sh" role="src" />
-<file md5sum="68bf12518c8007c0cbe4521b90174641" name="cci-src/external/libregex38a/regmem.c" role="src" />
-<file md5sum="4b5c460e791e312aeb0e3b02d616730e" name="cci-src/external/libregex38a/regcomp.ih" role="src" />
-<file md5sum="e50abbbe352d63b7aafc0cc5960be5cc" name="cci-src/external/libregex38a/regmem.ih" role="src" />
-<file md5sum="a1ad4822ccc53519fe519a9d353407d0" name="cci-src/external/libregex38a/config.sub" role="src" />
-<file md5sum="d41d8cd98f00b204e9800998ecf8427e" name="cci-src/external/libregex38a/ChangeLog" role="src" />
-<file md5sum="07bb8ebc51ae69c10390fb16cc547c34" name="cci-src/external/libregex38a/README" role="src" />
-<file md5sum="d7d8db17e074dcabf513d766b728993d" name="cci-src/external/libregex38a/depcomp" role="src" />
-<file md5sum="99305a6e51aaceee72c8929c3e13e532" name="cci-src/external/libregex38a/engine.c" role="src" />
-<file md5sum="6116430217dfd415f38d19ca1acb9b30" name="cci-src/external/libregex38a/regfree.c" role="src" />
-<file md5sum="e2593b6e07c12c2b7b5019216e288075" name="cci-src/external/libregex38a/Makefile.am" role="src" />
-<file md5sum="e46dcc68772fb4790c803ff7d28f9980" name="cci-src/external/libregex38a/regex2.h" role="src" />
-<file md5sum="afb242f3a24447c774ab082027663109" name="cci-src/external/libregex38a/regcomp.c" role="src" />
-<file md5sum="05b9ccb954f381da1d93b2a92d44ca75" name="cci-src/external/libregex38a/engine.ih" role="src" />
-<file md5sum="dc5485bb394a13b2332ec1c785f5d83a" name="cci-src/external/libregex38a/COPYING" role="src" />
-<file md5sum="5d58f0dd4262171a71b65bd515d85d07" name="cci-src/external/libregex38a/missing" role="src" />
-<file md5sum="ce785af2c9c33dad261e255cd91a9a89" name="cci-src/external/libregex38a/ltmain.sh" role="src" />
-<file md5sum="7abc6d9d2fb7d78cc690bcf16d5c49d5" name="cci-src/external/libregex38a/cname.h" role="src" />
-<file md5sum="617074e54fd24202d3cf58f30408ec2a" name="cci-src/external/libregex38a/regerror.ih" role="src" />
-<file md5sum="9109dd8c2735485d0752877ddc92b5ae" name="cci-src/external/libregex38a/utils.h" role="src" />
-<file md5sum="b47003c4b16301ae16f32b402d55a7cd" name="cci-src/external/Makefile.in" role="src" />
-<file md5sum="1f506099ebda5fa0a19f5753f0ae5c3c" name="cci-src/external/Makefile.am" role="src" />
-<file md5sum="4593bb26615130479f67ee5a9274ac8b" name="cci-src/CREDITS" role="src" />
-<file md5sum="f3bc32bf7cfdfdcbcdb89e1ac6d392a3" name="cci-src/acinclude.m4" role="src" />
-<file md5sum="ff8fe2cd44616a694c4acc34e83f8735" name="cci-src/win/cas_cci/cas_cci.vcproj" role="src" />
-<file md5sum="a0185e5840c9711ca979d4a384c10def" name="cci-src/win/cas_cci/cas_cci.vcxproj" role="src" />
-<file md5sum="258d9f2b577d3df789c25867fb586d80" name="cci-src/win/version.h" role="src" />
-<file md5sum="450d5d9b7c3f0eb9fc4db780a7eed7df" name="cci-src/win/external/lib64/libregex38a.lib" role="src" />
-<file md5sum="df609d3af6b6ba8a3ef75e6714e5a1f1" name="cci-src/win/external/include/regex38a.h" role="src" />
-<file md5sum="d135fe2923694e0b9fea77d46ac78e9d" name="cci-src/win/external/lib/libregex38a.lib" role="src" />
-<file md5sum="f875b34bb4f4fb949072438fc34b6bb9" name="cci-src/win/config.h" role="src" />
-<file md5sum="1841688047c381586cb0092f75d703e5" name="cci-src/win/cascci/cascci.vcproj" role="src" />
-<file md5sum="4bd2cad9c59ab88fd1e0c9543fdc96d0" name="cci-src/win/cascci/cascci.def" role="src" />
-<file md5sum="69d58a4b4b5a7b89d4475fb073eb2dae" name="cci-src/config.h.in" role="src" />
-<file md5sum="0d4c64e9c6b975d81a81812c3ab55f60" name="cci-src/Makefile.in" role="src" />
-<file md5sum="b2a35e98453194ca837c363ee9c0d379" name="cci-src/config/compile" role="src" />
-<file md5sum="7fc030a85a8f3d4864a65db5fb70c794" name="cci-src/config/config.guess" role="src" />
-<file md5sum="aded5875c5d5830de6653181e8ced19c" name="cci-src/config/install-sh" role="src" />
-<file md5sum="a1ad4822ccc53519fe519a9d353407d0" name="cci-src/config/config.sub" role="src" />
-<file md5sum="d7d8db17e074dcabf513d766b728993d" name="cci-src/config/depcomp" role="src" />
-<file md5sum="5d58f0dd4262171a71b65bd515d85d07" name="cci-src/config/missing" role="src" />
-<file md5sum="ce785af2c9c33dad261e255cd91a9a89" name="cci-src/config/ltmain.sh" role="src" />
-<file md5sum="d4aac9b7fec0b4e451c51a6b36ebb2e2" name="cci-src/include/Makefile.in" role="src" />
-<file md5sum="76cfbb2ca1d712972df6d5a97bd50eac" name="cci-src/include/system.h" role="src" />
-<file md5sum="0a7417388288cf06e56fdcf62ca02f83" name="cci-src/include/Makefile.am" role="src" />
-<file md5sum="c76724a9ce5a32a0ff7820737ef15cee" name="cci-src/cci/Makefile.in" role="src" />
-<file md5sum="a76b5791b5471efdf303c129ebf8c6ac" name="cci-src/cci/Makefile.am" role="src" />
-<file md5sum="f9fb1563e711b442edbe4bbcb1cc9846" name="cci-src/README" role="src" />
-<file md5sum="e4101be9059ba352b26f2875558229c1" name="cci-src/src/broker/cas_error.h" role="src" />
-<file md5sum="db11f6e919c8374196d9d6ee823c0a21" name="cci-src/src/broker/cas_protocol.h" role="src" />
-<file md5sum="8491b22dde36a83eb6269ad6c9e3895b" name="cci-src/src/cci/cci_properties.c" role="src" />
-<file md5sum="62c535b19b33e393f6101028a5f24347" name="cci-src/src/cci/cci_handle_mng.h" role="src" />
-<file md5sum="684810b466a7b63ce54a76ae36441a55" name="cci-src/src/cci/cci_common.c" role="src" />
-<file md5sum="536fc91913ebdfc56bd7d659ef8b6707" name="cci-src/src/cci/cci_network.h" role="src" />
-<file md5sum="9faf1525738e409bdd0eb184de2dfb44" name="cci-src/src/cci/cci_wsa_init.h" role="src" />
-<file md5sum="141cb2e9ab27b888b5be2b6b580d876e" name="cci-src/src/cci/cci_log.h" role="src" />
-<file md5sum="38994cbca0b3c63c3ec92c178e54ca76" name="cci-src/src/cci/cci_t_set.c" role="src" />
-<file md5sum="db6124f562e57356ab4ac357fbed3b09" name="cci-src/src/cci/cci_mutex.h" role="src" />
-<file md5sum="2bf1e215e8cfac1c3986b7cc7aa6343b" name="cci-src/src/cci/cci_common.h" role="src" />
-<file md5sum="b0a8ab559151465eb90d82614ccac2e8" name="cci-src/src/cci/cci_map.h" role="src" />
-<file md5sum="3c4592016a70f67624063de0ad6faa64" name="cci-src/src/cci/cci_net_buf.h" role="src" />
-<file md5sum="dfe0470e81c33324e28ce4ffbd0224a8" name="cci-src/src/cci/cci_xa.h" role="src" />
-<file md5sum="54b71c28b9a41b7b4538f0c67e38fbbb" name="cci-src/src/cci/cci_query_execute.h" role="src" />
-<file md5sum="9f95d67b7b63fd809c93c21fe1ccf7ad" name="cci-src/src/cci/cci_t_lob.h" role="src" />
-<file md5sum="809a72383c94587a7d722053d3674556" name="cci-src/src/cci/cci_map.cpp" role="src" />
-<file md5sum="b5401392efe00595a17e56c177cb62db" name="cci-src/src/cci/cci_util.h" role="src" />
-<file md5sum="9840442d42f256e7f83a4328670884d4" name="cci-src/src/cci/cas_cci.c" role="src" />
-<file md5sum="51116cef6c6b638ebe3f36605dddd808" name="cci-src/src/cci/cci_handle_mng.c" role="src" />
-<file md5sum="269549777d4e3cc4d3c0a320d8013662" name="cci-src/src/cci/cci_log.cpp" role="src" />
-<file md5sum="2b8bc31643ec79875622e84a3dea1183" name="cci-src/src/cci/cci_query_execute.c" role="src" />
-<file md5sum="8e48abfaf16625537281688e4f260130" name="cci-src/src/cci/cci_net_buf.c" role="src" />
-<file md5sum="6f43a327f84471ff35eccc1c4b589743" name="cci-src/src/cci/cci_t_lob.c" role="src" />
-<file md5sum="8a942da872c2e5d965f0a26998e2622c" name="cci-src/src/cci/cci_network.c" role="src" />
-<file md5sum="e2f5fffb2efa84830df80ffe77b787e1" name="cci-src/src/cci/cci_wsa_init.c" role="src" />
-<file md5sum="fc629026e43b35360b2292f3512a46f3" name="cci-src/src/cci/cas_cci.h" role="src" />
-<file md5sum="658887d4a8beff7453f202f9723f1174" name="cci-src/src/cci/cci_t_set.h" role="src" />
-<file md5sum="a420a644ff0a2a2cecd1b53189925690" name="cci-src/src/cci/cci_util.c" role="src" />
-<file md5sum="1a55abc7f817d34dd4c3313c573f53b3" name="cci-src/src/base/error_code.h" role="src" />
-<file md5sum="82b61982f9b368612cca8e509f9fb5fe" name="cci-src/src/base/rand.c" role="src" />
-<file md5sum="8a6d12aa60e8a12e88834bf2ddff80d7" name="cci-src/src/base/porting.c" role="src" />
-<file md5sum="c28217e68d451fb075842845487ed000" name="cci-src/src/base/stringl.h" role="src" />
-<file md5sum="361273c386669d258c1a2e30ae4cd5e6" name="cci-src/src/base/porting.h" role="src" />
-<file md5sum="f29638e1a33dde3384388311517f1929" name="cci-src/src/base/getopt.h" role="src" />
-<file md5sum="d7c8df22554e630d27c93d8e6ebe51f9" name="cci-src/Makefile.am" role="src" />
-<file md5sum="7bd44c0bd8c784d30fac4402752d5d9f" name="cci-src/BUILD_NUMBER" role="src" />
-<file md5sum="64915df509d5c77db6402b5072e26b78" name="cci-src/COPYING" role="src" />
-<file md5sum="33eca35f1f7369fa7c13bb00b5ff6c58" name="php_pdo_cubrid_int.h" role="src" />
-<file md5sum="0eee76f0411c1ebd5515a7961ce96615" name="cubrid_driver.c" role="src" />
-<file md5sum="19eb0dfe0a28fa4614665012f44ba41a" name="cubrid_statement.c" role="src" />
-<file md5sum="f5d5d95d10d5ad1ad8e0f9a8a3dedf7b" name="pdo_cubrid_version.h" role="src" />
-<file md5sum="512cc9ce6bed2344e1d9d47528c175c6" name="pdo_cubrid.dsp" role="src" />
-<file md5sum="f3a2b39c88eee776ef79358ee80f0fdd" name="php_pdo_cubrid.h" role="src" />
+<file name="config.w32" role="src" />
+<file name="config.m4" role="src" />
+<file name="CREDITS" role="src" />
+<file name="win/VC11/pdo_cubrid.vcxproj" role="src" />
+<file name="win/VC11/pdo_cubrid.sln" role="src" />
+<file name="win/pdo_cubrid.sln" role="src" />
+<file name="win/pdo_cubrid.vcproj" role="src" />
+<file name="pdo_cubrid.c" role="src" />
+<file name="tests/bug_36428.phpt" role="src" />
+<file name="tests/pdo_025.phpt" role="src" />
+<file name="tests/bug_36798.phpt" role="src" />
+<file name="tests/bug47769.phpt" role="src" />
+<file name="tests/pdo_001.phpt" role="src" />
+<file name="tests/pdo_023.phpt" role="src" />
+<file name="tests/pdo_034.phpt" role="src" />
+<file name="tests/pdo.inc" role="src" />
+<file name="tests/pdo_028.phpt" role="src" />
+<file name="tests/pdo_038.phpt" role="src" />
+<file name="tests/bug_50458.phpt" role="src" />
+<file name="tests/pdo_018.phpt" role="src" />
+<file name="tests/pdo_003.phpt" role="src" />
+<file name="tests/bug_43663.phpt" role="src" />
+<file name="tests/pdo_004.phpt" role="src" />
+<file name="tests/pdo_016a.phpt" role="src" />
+<file name="tests/bug_40285.phpt" role="src" />
+<file name="tests/pdo_027.phpt" role="src" />
+<file name="tests/pdo_039.phpt" role="src" />
+<file name="tests/bug_39398.phpt" role="src" />
+<file name="tests/pdo_014.phpt" role="src" />
+<file name="tests/bug_44159.phpt" role="src" />
+<file name="tests/pdo_041.phpt" role="src" />
+<file name="tests/pdo_enum.phpt" role="src" />
+<file name="tests/bug_43139.phpt" role="src" />
+<file name="tests/pecl_bug_5772.phpt" role="src" />
+<file name="tests/pdo_020.phpt" role="src" />
+<file name="tests/pdo_029.phpt" role="src" />
+<file name="tests/bug_44409.phpt" role="src" />
+<file name="tests/bug_39656.phpt" role="src" />
+<file name="tests/bug_38394.phpt" role="src" />
+<file name="tests/pdo_007.phpt" role="src" />
+<file name="tests/pdo_002.phpt" role="src" />
+<file name="tests/bug_42917.phpt" role="src" />
+<file name="tests/pdo_009.phpt" role="src" />
+<file name="tests/pecl_bug_5217.phpt" role="src" />
+<file name="tests/bug_34687.phpt" role="src" />
+<file name="tests/pdo_010.phpt" role="src" />
+<file name="tests/pdo_013.phpt" role="src" />
+<file name="tests/pdo_033.phpt" role="src" />
+<file name="tests/pdo_011.phpt" role="src" />
+<file name="tests/pdo_037.phpt" role="src" />
+<file name="tests/pdo_032.phpt" role="src" />
+<file name="tests/pdo_015.phpt" role="src" />
+<file name="tests/pdo_012.phpt" role="src" />
+<file name="tests/pdo_036.phpt" role="src" />
+<file name="tests/pdo_019.phpt" role="src" />
+<file name="tests/pdorow.phpt" role="src" />
+<file name="tests/pdo_022.phpt" role="src" />
+<file name="tests/pecl_bug_5809.phpt" role="src" />
+<file name="tests/bug_44173.phpt" role="src" />
+<file name="tests/bug_44861.phpt" role="src" />
+<file name="tests/pdo_test.inc" role="src" />
+<file name="tests/bug_38253.phpt" role="src" />
+<file name="tests/pdo_017.phpt" role="src" />
+<file name="tests/pdo_031.phpt" role="src" />
+<file name="tests/pdo_cubrid_stmt_getcolumnmeta.phpt" role="src" />
+<file name="tests/bug_35671.phpt" role="src" />
+<file name="tests/pdo_035.phpt" role="src" />
+<file name="tests/run-tests.php" role="src" />
+<file name="tests/pdo_008.phpt" role="src" />
+<file name="tests/pdo_021.phpt" role="src" />
+<file name="tests/pdo_024.phpt" role="src" />
+<file name="tests/pdo_026.phpt" role="src" />
+<file name="tests/pdo_040.phpt" role="src" />
+<file name="tests/pdo_030.phpt" role="src" />
+<file name="tests/pdo_006.phpt" role="src" />
+<file name="tests/pdo_005.phpt" role="src" />
+<file name="tests/pdo_016.phpt" role="src" />
+<file name="tests/bug_34630.phpt" role="src" />
+<file name="README" role="src" />
+<file name="cci-src/autogen.sh" role="src" />
+<file name="cci-src/configure.ac" role="src" />
+<file name="cci-src/configure" role="src" />
+<file name="cci-src/build.sh" role="src" />
+<file name="cci-src/aclocal.m4" role="src" />
+<file name="cci-src/src/api/cubrid_api.h" role="src" />
+<file name="cci-src/src/compat/dbi_compat.h" role="src" />
+<file name="cci-src/external/libregex38a/configure.ac" role="src" />
+<file name="cci-src/external/libregex38a/regerror.c" role="src" />
+<file name="cci-src/external/libregex38a/configure.gnu" role="src" />
+<file name="cci-src/external/libregex38a/config.guess" role="src" />
+<file name="cci-src/external/libregex38a/configure" role="src" />
+<file name="cci-src/external/libregex38a/NEWS" role="src" />
+<file name="cci-src/external/libregex38a/regexec.c" role="src" />
+<file name="cci-src/external/libregex38a/aclocal.m4" role="src" />
+<file name="cci-src/external/libregex38a/cclass.h" role="src" />
+<file name="cci-src/external/libregex38a/config.h.in" role="src" />
+<file name="cci-src/external/libregex38a/AUTHORS" role="src" />
+<file name="cci-src/external/libregex38a/Makefile.in" role="src" />
+<file name="cci-src/external/libregex38a/include/regex38a.h" role="src" />
+<file name="cci-src/external/libregex38a/include/Makefile.in" role="src" />
+<file name="cci-src/external/libregex38a/include/Makefile.am" role="src" />
+<file name="cci-src/external/libregex38a/INSTALL" role="src" />
+<file name="cci-src/external/libregex38a/install-sh" role="src" />
+<file name="cci-src/external/libregex38a/regmem.c" role="src" />
+<file name="cci-src/external/libregex38a/regcomp.ih" role="src" />
+<file name="cci-src/external/libregex38a/regmem.ih" role="src" />
+<file name="cci-src/external/libregex38a/config.sub" role="src" />
+<file name="cci-src/external/libregex38a/ChangeLog" role="src" />
+<file name="cci-src/external/libregex38a/README" role="src" />
+<file name="cci-src/external/libregex38a/depcomp" role="src" />
+<file name="cci-src/external/libregex38a/engine.c" role="src" />
+<file name="cci-src/external/libregex38a/regfree.c" role="src" />
+<file name="cci-src/external/libregex38a/Makefile.am" role="src" />
+<file name="cci-src/external/libregex38a/regex2.h" role="src" />
+<file name="cci-src/external/libregex38a/regcomp.c" role="src" />
+<file name="cci-src/external/libregex38a/engine.ih" role="src" />
+<file name="cci-src/external/libregex38a/COPYING" role="src" />
+<file name="cci-src/external/libregex38a/missing" role="src" />
+<file name="cci-src/external/libregex38a/ltmain.sh" role="src" />
+<file name="cci-src/external/libregex38a/cname.h" role="src" />
+<file name="cci-src/external/libregex38a/regerror.ih" role="src" />
+<file name="cci-src/external/libregex38a/utils.h" role="src" />
+<file name="cci-src/external/Makefile.in" role="src" />
+<file name="cci-src/external/Makefile.am" role="src" />
+<file name="cci-src/CREDITS" role="src" />
+<file name="cci-src/acinclude.m4" role="src" />
+<file name="cci-src/win/cas_cci/cas_cci.vcproj" role="src" />
+<file name="cci-src/win/cas_cci/cas_cci.vcxproj" role="src" />
+<file name="cci-src/win/version.h" role="src" />
+<file name="cci-src/win/external/lib64/libregex38a.lib" role="src" />
+<file name="cci-src/win/external/include/regex38a.h" role="src" />
+<file name="cci-src/win/external/lib/libregex38a.lib" role="src" />
+<file name="cci-src/win/config.h" role="src" />
+<file name="cci-src/win/cascci/cascci.vcproj" role="src" />
+<file name="cci-src/win/cascci/cascci.def" role="src" />
+<file name="cci-src/config.h.in" role="src" />
+<file name="cci-src/Makefile.in" role="src" />
+<file name="cci-src/config/compile" role="src" />
+<file name="cci-src/config/config.guess" role="src" />
+<file name="cci-src/config/install-sh" role="src" />
+<file name="cci-src/config/config.sub" role="src" />
+<file name="cci-src/config/depcomp" role="src" />
+<file name="cci-src/config/missing" role="src" />
+<file name="cci-src/config/ltmain.sh" role="src" />
+<file name="cci-src/include/Makefile.in" role="src" />
+<file name="cci-src/include/system.h" role="src" />
+<file name="cci-src/include/Makefile.am" role="src" />
+<file name="cci-src/cci/Makefile.in" role="src" />
+<file name="cci-src/cci/Makefile.am" role="src" />
+<file name="cci-src/README" role="src" />
+<file name="cci-src/src/broker/cas_error.h" role="src" />
+<file name="cci-src/src/broker/cas_protocol.h" role="src" />
+<file name="cci-src/src/cci/cci_properties.c" role="src" />
+<file name="cci-src/src/cci/cci_handle_mng.h" role="src" />
+<file name="cci-src/src/cci/cci_common.c" role="src" />
+<file name="cci-src/src/cci/cci_network.h" role="src" />
+<file name="cci-src/src/cci/cci_wsa_init.h" role="src" />
+<file name="cci-src/src/cci/cci_log.h" role="src" />
+<file name="cci-src/src/cci/cci_t_set.c" role="src" />
+<file name="cci-src/src/cci/cci_mutex.h" role="src" />
+<file name="cci-src/src/cci/cci_common.h" role="src" />
+<file name="cci-src/src/cci/cci_map.h" role="src" />
+<file name="cci-src/src/cci/cci_net_buf.h" role="src" />
+<file name="cci-src/src/cci/cci_xa.h" role="src" />
+<file name="cci-src/src/cci/cci_query_execute.h" role="src" />
+<file name="cci-src/src/cci/cci_t_lob.h" role="src" />
+<file name="cci-src/src/cci/cci_map.cpp" role="src" />
+<file name="cci-src/src/cci/cci_util.h" role="src" />
+<file name="cci-src/src/cci/cas_cci.c" role="src" />
+<file name="cci-src/src/cci/cci_handle_mng.c" role="src" />
+<file name="cci-src/src/cci/cci_log.cpp" role="src" />
+<file name="cci-src/src/cci/cci_query_execute.c" role="src" />
+<file name="cci-src/src/cci/cci_net_buf.c" role="src" />
+<file name="cci-src/src/cci/cci_t_lob.c" role="src" />
+<file name="cci-src/src/cci/cci_network.c" role="src" />
+<file name="cci-src/src/cci/cci_wsa_init.c" role="src" />
+<file name="cci-src/src/cci/cas_cci.h" role="src" />
+<file name="cci-src/src/cci/cci_t_set.h" role="src" />
+<file name="cci-src/src/cci/cci_util.c" role="src" />
+<file name="cci-src/src/base/error_code.h" role="src" />
+<file name="cci-src/src/base/rand.c" role="src" />
+<file name="cci-src/src/base/porting.c" role="src" />
+<file name="cci-src/src/base/porting.h" role="src" />
+<file name="cci-src/src/base/getopt.h" role="src" />
+<file name="cci-src/Makefile.am" role="src" />
+<file name="cci-src/BUILD_NUMBER" role="src" />
+<file name="cci-src/COPYING" role="src" />
+<file name="php_pdo_cubrid_int.h" role="src" />
+<file name="cubrid_driver.c" role="src" />
+<file name="cubrid_driver7.c" role="src" />
+<file name="cubrid_statement.c" role="src" />
+<file name="cubrid_statement7.c" role="src" />
+<file name="pdo_cubrid_version.h" role="src" />
+<file name="pdo_cubrid.dsp" role="src" />
+<file name="php_pdo_cubrid.h" role="src" />
 
 
   </dir>
@@ -238,6 +242,21 @@
  </extsrcrelease>
  <changelog>
  
+ <release>
+ <version>
+  <release>9.3.0.0001</release>
+  <api>9.3.0</api>
+ </version>
+ <stability>
+  <release>stable</release>
+  <api>stable</api>
+ </stability>
+ <license uri="http://www.php.net/license">PHP</license>
+ <notes>
+  Support cubrid engine version up to 9.3
+ </notes>
+</release>
+
   <release>
 <version>
   <release>9.1.0.0002</release>


### PR DESCRIPTION
Default port and server has been updated 33000--> 55300 but this will not be affected on execution of PDO driver because the port is ignored by PHP's driver option.
