### PR TITLE
[APIS-773] Modify/Remove broken link in README (PDO)

### DIFF
--- a/README
+++ b/README
@@ -6,7 +6,7 @@ CUBRID PDO Library
 CUBRID PDO Library is the official PDO Extension to connect to CUBRID Database.
 
 For more information about CUBRID PDO Library, visit the web site:
-http://www.cubrid.org/wiki_apis/entry/cubrid-pdo-driver
+https://www.cubrid.org/manual/en/10.1/api/pdo.html
 
 For more information about CUBRID, visit the web site: 
 http://www.cubrid.org
@@ -16,10 +16,10 @@ http://www.cubrid.org
 CUBRID and CUBRID APIs are developed with open source projects.
 
 For more information about CUBRID APIs project, visit the web site:
-http://www.cubrid.org/wiki_apis/entry/cubrid-apis-wiki
+https://www.cubrid.org/manual/en/10.1/api/index.html
 
 For more information about CUBRID project, visit the web site: 
-http://sourceforge.net/projects/cubrid/
+https://github.com/CUBRID
 
 3. License
 
@@ -27,22 +27,18 @@ CUBRID is distributed under two licenses,
 Database engine is under GPL v2 or later and the APIs are under BSD license.
 
 For more information, visit the web site:
-http://www.cubrid.org/license
+https://www.cubrid.org/manual/en/10.1/release_note/index.html#license
 
 4. Build
 
 The latest version of CUBRID PDO Library can be found at: 
-http://www.cubrid.org/wiki_apis/entry/cubrid-pdo-driver
+http://ftp.cubrid.org/CUBRID_Drivers/PHP_Driver/PDO/
 
 More detailed build manual can be found at: 
-http://www.cubrid.org/wiki_apis/entry/cubrid-pdo-driver-installation-instructions
+https://www.cubrid.org/manual/en/10.1/api/adodotnet.html#installing-and-configuring-ado-net
 
 5. Source modules
 
 CUBRID PDO Library source modules and its structure can be found at: 
-http://svn.cubrid.org/cubridapis/pdo/
+https://github.com/CUBRID/cubrid-pdo
 
-6. FAQ
-
-If you have questions, have a look at the CUBRID PDO FAQ:
-http://www.cubrid.org/?mid=questions&tag=PHP


### PR DESCRIPTION
Modify/Remove broken link in README or Wiki at github/CUBRID repositories

The links in README file is modified for correct information.
The FAQ link has been removed.