### PR TITLE
[APIS-803] Driver Release for 10.2 (#13)

### DIFF
--- a/README
+++ b/README
@@ -6,7 +6,9 @@ CUBRID PDO Library
 CUBRID PDO Library is the official PDO Extension to connect to CUBRID Database.
 
 For more information about CUBRID PDO Library, visit the web site:
-https://www.cubrid.org/manual/en/10.1/api/pdo.html
+
+https://www.cubrid.org/manual/en/10.2/api/pdo.html
+
 
 For more information about CUBRID, visit the web site: 
 http://www.cubrid.org
@@ -16,7 +18,9 @@ http://www.cubrid.org
 CUBRID and CUBRID APIs are developed with open source projects.
 
 For more information about CUBRID APIs project, visit the web site:
-https://www.cubrid.org/manual/en/10.1/api/index.html
+
+https://www.cubrid.org/manual/en/10.2/api/index.html
+
 
 For more information about CUBRID project, visit the web site: 
 https://github.com/CUBRID
@@ -27,7 +31,9 @@ CUBRID is distributed under two licenses,
 Database engine is under GPL v2 or later and the APIs are under BSD license.
 
 For more information, visit the web site:
-https://www.cubrid.org/manual/en/10.1/release_note/index.html#license
+
+https://www.cubrid.org/manual/en/10.2/release_note/index.html#license
+
 
 4. Build
 
@@ -35,7 +41,9 @@ The latest version of CUBRID PDO Library can be found at:
 http://ftp.cubrid.org/CUBRID_Drivers/PHP_Driver/PDO/
 
 More detailed build manual can be found at: 
-https://www.cubrid.org/manual/en/10.1/api/adodotnet.html#installing-and-configuring-ado-net
+
+https://www.cubrid.org/manual/en/10.2/api/adodotnet.html#installing-and-configuring-ado-net
+
 
 5. Source modules
 


### PR DESCRIPTION
* [APIS-758] PDO Driver Update for PHP version 7 and CUBRID 10.1.0 (#3)

* [APIS-762] PDO Driver crashed (core dumped) while running cubrid_handle_preparer on PHP7 (#4)

* add tests_7 for pdo7 and modify some phpt for pdo5 (#5)

* [APIS-767] in PHP 7, bindParam resource is accessed by indirect via R… (#6)

* [APIS-767] in PHP 7, bindParam resource is accessed by indirect via REF type of zval.

* [APIS-767] version modified to '10.1.0.0003' for a new driver release

* Apis 770 (#7)

* Creating solution files for PDO driver on PHP5 and PHP7

* [APIS-770] vcxproj files are modified to separate output dll file for PHP5 and PHP7.

* [APIS-770] renamed and modified the project and solution files php5 and php7.

* [APIS-770] pdo7_cubrid.vcxproj modified for correct build target configuration of NTS/TS

* [APIS-773] Modify/Remove broken link in README (#8)

* [APIS-803] Driver Release for 10.2

* Apis 803 (#9)

* [APIS-803] Driver Release for 10.2

* [APIS-803] modifying project files for unified directory and DLL file name

* [APIS-803] solution file names are renamed

* [APIS-808] Modify sub-module reference to the new version 10.2 [cci-src] (#10)

* [APIS-808] modified config.m4 and cci-src ref. as modifying cci-src configure

* [APIS-808] modified reference to submodule cc-src

* [APIS-803] update link for 10.2 release (#12)