### PR TITLE
[APIS-844] openssl lib link and zend api (php7.3) changes applied

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -37,8 +37,6 @@ if test "$PHP_PDO_CUBRID" != "no"; then
     	    AC_MSG_NOTICE([Build static cci lib 64 bits])
             pushd $CCISRC_DIR
             chmod +x configure
-            chmod +x external/libregex38a/configure
-            chmod +x external/libregex38a/install-sh
             ./configure --enable-64bit
     	    make
             popd
@@ -46,8 +44,6 @@ if test "$PHP_PDO_CUBRID" != "no"; then
     	    AC_MSG_NOTICE([Build static cci lib])
             pushd $CCISRC_DIR
             chmod +x configure
-            chmod +x external/libregex38a/configure
-            chmod +x external/libregex38a/install-sh
             ./configure
     	    make
             popd
@@ -64,8 +60,6 @@ if test "$PHP_PDO_CUBRID" != "no"; then
     	    AC_MSG_NOTICE([Build static cci lib 64 bits])
             pushd $CCISRC_DIR
             chmod +x configure
-            chmod +x external/libregex38a/configure
-            chmod +x external/libregex38a/install-sh
             ./configure--enable-64bit
     	    make
             popd
@@ -73,8 +67,6 @@ if test "$PHP_PDO_CUBRID" != "no"; then
     	    AC_MSG_NOTICE([Build static cci lib])
             pushd $CCISRC_DIR
             chmod +x configure
-            chmod +x external/libregex38a/configure
-            chmod +x external/libregex38a/install-sh
             ./configure
     	    make
             popd
@@ -111,7 +103,7 @@ if test "$PHP_PDO_CUBRID" != "no"; then
 
     PHP_ADD_LIBRARY(stdc++, , PDO_CUBRID_SHARED_LIBADD)
     PHP_ADD_LIBRARY(pthread, , PDO_CUBRID_SHARED_LIBADD)
-    LDFLAGS="$LDFLAGS $CUBRID_LIBDIR/libcascci.a -lpthread"
+    LDFLAGS="$LDFLAGS $CUBRID_LIBDIR/libcascci.a -lpthread  $cubrid_dir/cci-src/external/openssl/lib/libssl.a $cubrid_dir/cci-src/external/openssl/lib/libcrypto.a"
   
     PHP_SUBST(PDO_CUBRID_SHARED_LIBADD)
 

--- a/cubrid_driver7.c
+++ b/cubrid_driver7.c
@@ -90,7 +90,7 @@ static int cubrid_get_err_msg(int err_code, char *err_buf, int buf_size);
 static int get_db_param(pdo_cubrid_db_handle *H, T_CCI_ERROR *error);
 static int fetch_a_row(zval *arg, int req_handle, int type TSRMLS_DC);
 static int cubrid_array_destroy(HashTable * ht ZEND_FILE_LINE_DC);
-static int cubrid_add_index_array(zval *arg, uint index, T_CCI_SET in_set TSRMLS_DC);
+static int cubrid_add_index_array(zval *arg, zend_ulong index, T_CCI_SET in_set TSRMLS_DC);
 static int cubrid_add_assoc_array(zval *arg, char *key, T_CCI_SET in_set TSRMLS_DC);
 
 /************************************************************************
@@ -982,7 +982,7 @@ static int fetch_a_row(zval *arg, int req_handle, int type TSRMLS_DC)
 				}
 			} else {
 				if (type & CUBRID_NUM) {
-					cubrid_retval = cubrid_add_index_array(arg, i, res_buf TSRMLS_CC);
+					cubrid_retval = cubrid_add_index_array(arg, (zend_ulong)i, res_buf TSRMLS_CC);
 				} 
 				
 				if (type & CUBRID_ASSOC) {
@@ -1037,7 +1037,7 @@ static int cubrid_array_destroy(HashTable * ht ZEND_FILE_LINE_DC)
     return SUCCESS;
 }
 
-static int cubrid_add_index_array(zval *arg, uint index, T_CCI_SET in_set TSRMLS_DC)
+static int cubrid_add_index_array(zval *arg, zend_ulong index, T_CCI_SET in_set TSRMLS_DC)
 {
     zval tmp_zval;
 

--- a/cubrid_statement7.c
+++ b/cubrid_statement7.c
@@ -1175,7 +1175,11 @@ static int cubrid_lob_stream_close(php_stream *stream, int close_handle TSRMLS_D
 
 	if (close_handle) {
         zend_object *obj = &stmt->std;
-        GC_REFCOUNT(obj)--;
+#if ZEND_MODULE_API_NO >= 20190902
+		GC_DELREF(obj);
+#else
+		GC_REFCOUNTfsadf(obj)--;
+#endif
 		cubrid_lob_free(self->lob, self->type);
 	}
 	efree(self);
@@ -1314,7 +1318,11 @@ static php_stream *cubrid_create_lob_stream(pdo_stmt_t *stmt, T_CCI_LOB lob, T_C
 	if (stm) {
         zend_object *obj;
         obj = &stmt->std;
-        GC_REFCOUNT(obj)++;
+#if ZEND_MODULE_API_NO >= 20190902
+		GC_ADDREF(obj);
+#else
+		GC_REFCOUNT(obj)++;
+#endif
 		return stm;
 	}
 

--- a/cubrid_statement7.c
+++ b/cubrid_statement7.c
@@ -1178,7 +1178,7 @@ static int cubrid_lob_stream_close(php_stream *stream, int close_handle TSRMLS_D
 #if ZEND_MODULE_API_NO >= 20190902
         GC_DELREF(obj);
 #else
-        GC_REFCOUNTfsadf(obj)--;
+        GC_REFCOUNT(obj)--;
 #endif
 		cubrid_lob_free(self->lob, self->type);
 	}

--- a/cubrid_statement7.c
+++ b/cubrid_statement7.c
@@ -1176,9 +1176,9 @@ static int cubrid_lob_stream_close(php_stream *stream, int close_handle TSRMLS_D
 	if (close_handle) {
         zend_object *obj = &stmt->std;
 #if ZEND_MODULE_API_NO >= 20190902
-		GC_DELREF(obj);
+        GC_DELREF(obj);
 #else
-		GC_REFCOUNTfsadf(obj)--;
+        GC_REFCOUNTfsadf(obj)--;
 #endif
 		cubrid_lob_free(self->lob, self->type);
 	}
@@ -1319,9 +1319,9 @@ static php_stream *cubrid_create_lob_stream(pdo_stmt_t *stmt, T_CCI_LOB lob, T_C
         zend_object *obj;
         obj = &stmt->std;
 #if ZEND_MODULE_API_NO >= 20190902
-		GC_ADDREF(obj);
+        GC_ADDREF(obj);
 #else
-		GC_REFCOUNT(obj)++;
+        GC_REFCOUNT(obj)++;
 #endif
 		return stm;
 	}

--- a/pdo_cubrid7.vcxproj
+++ b/pdo_cubrid7.vcxproj
@@ -522,7 +522,6 @@
       <Culture>0x0804</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalOptions>/libpath:""$(CUBRID)\lib"" %(AdditionalOptions)</AdditionalOptions>
       <AdditionalDependencies>odbc32.lib;odbccp32.lib;ws2_32.lib;cas_cci.lib;php7.lib;libssl.lib;libcrypto.lib;Crypt32.lib;msvcrt.lib;msvcmrt.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(RootNamespace)__$(Platform)_$(Configuration)/$(RootNamespace).dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
@@ -532,6 +531,7 @@
       <DataExecutionPrevention />
       <ImportLibrary>.\$(Configuration)/php_pdo_cubrid.lib</ImportLibrary>
       <TargetMachine>MachineX64</TargetMachine>
+      <AdditionalOptions />
     </Link>
     <Bscmake>
       <SuppressStartupBanner>true</SuppressStartupBanner>


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-844

* Add openssl lib link in php config.m4
* Delete unnecessary options (vs2015 project file)
* Zend API of PHP7 applies changes
    If zend api is 20190902,
    GC_REFCOUNT(obj)--   ==>  GC_DELREF(obj)
    GC_REFCOUNT(obj)++ ==>  GC_ADDREF(obj)
    Changed to.