### PR TITLE
[CBRD-24271] Modify build environment for drivers that use the CCI driver source or file.

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -14,10 +14,8 @@ PHP_MAJOR_VERSION=`grep 'PHP_MAJOR_VERSION' $phpincludedir/main/php_version.h | 
 if test "$PHP_PDO_CUBRID" != "no"; then
 
     cubrid_dir=`dirname $0`
-    COMPAT_INCDIR=""
     CUBRID_INCDIR=""
     CUBRID_LIBDIR=""
-    BROKER_INCDIR=""
 
     case $host in
       *-linux-*) os=linux ;;
@@ -26,54 +24,32 @@ if test "$PHP_PDO_CUBRID" != "no"; then
       *-apple-*) os=mac ;
     esac
     if test "$os" = "linux"; then
-        COMPAT_INCDIR="$cubrid_dir/cci-src/src/compat"
         CUBRID_INCDIR="$cubrid_dir/cci-src/src/cci"
-     	BROKER_INCDIR="$cubrid_dir/cci-src/src/broker"
-        CUBRID_LIBDIR="$cubrid_dir/cci-src/cci/.libs"
+        CUBRID_LIBDIR="$cubrid_dir/cci-src/build_x86_64_release/cci"
         CCISRC_DIR="$cubrid_dir/cci-src"
         AC_CHECK_SIZEOF([int *])
 
         if test "$ac_cv_sizeof_int_p" = "8"; then
     	    AC_MSG_NOTICE([Build static cci lib 64 bits])
             pushd $CCISRC_DIR
-            chmod +x configure
-            touch configure.ac
-            ./configure --enable-64bit
-    	    make
+            ./build.sh
             popd
         else
-    	    AC_MSG_NOTICE([Build static cci lib])
-            pushd $CCISRC_DIR
-            chmod +x configure
-            touch configure.ac
-            ./configure
-    	    make
-            popd
+          AC_MSG_ERROR([32bit Driver not supported. Exit.])
         fi
     elif test "$os" = "mac"; then
-        COMPAT_INCDIR="$cubrid_dir/cci-src/src/compat"
         CUBRID_INCDIR="$cubrid_dir/cci-src/src/cci"
-     	BROKER_INCDIR="$cubrid_dir/cci-src/src/broker"
-        CUBRID_LIBDIR="$cubrid_dir/cci-src/cci/.libs"
+        CUBRID_LIBDIR="$cubrid_dir/cci-src/build_x86_64_release/cci"
         CCISRC_DIR="$cubrid_dir/cci-src"
         AC_CHECK_SIZEOF([int *])
 
         if test "$ac_cv_sizeof_int_p" = "8"; then
     	    AC_MSG_NOTICE([Build static cci lib 64 bits])
             pushd $CCISRC_DIR
-            chmod +x configure
-            touch configure.ac
-            ./configure--enable-64bit
-    	    make
+            ./build.sh
             popd
         else
-    	    AC_MSG_NOTICE([Build static cci lib])
-            pushd $CCISRC_DIR
-            chmod +x configure
-            touch configure.ac
-            ./configure
-    	    make
-            popd
+          AC_MSG_ERROR([32bit Driver not supported. Exit.])
         fi     
     else
         AC_MSG_ERROR([Your OS not supported. Exit.])
@@ -101,9 +77,7 @@ if test "$PHP_PDO_CUBRID" != "no"; then
     fi
 
     dnl Action..
-    PHP_ADD_INCLUDE("$COMPAT_INCDIR")
     PHP_ADD_INCLUDE("$CUBRID_INCDIR")
-    PHP_ADD_INCLUDE("$BROKER_INCDIR")
 
     PHP_ADD_LIBRARY(stdc++, , PDO_CUBRID_SHARED_LIBADD)
     PHP_ADD_LIBRARY(pthread, , PDO_CUBRID_SHARED_LIBADD)

--- a/cubrid_driver.c
+++ b/cubrid_driver.c
@@ -39,6 +39,7 @@
 #include "php_pdo_cubrid.h"
 #include "php_pdo_cubrid_int.h"
 #include <cas_cci.h>
+#include <broker_cas_error.h>
 
 /************************************************************************
 * PRIVATE TYPE DEFINITIONS

--- a/cubrid_driver7.c
+++ b/cubrid_driver7.c
@@ -39,6 +39,7 @@
 #include "php_pdo_cubrid.h"
 #include "php_pdo_cubrid_int.h"
 #include <cas_cci.h>
+#include <broker_cas_error.h>
 
 #if !defined(add_assoc_unset)
 #define add_assoc_unset	add_assoc_null

--- a/cubrid_statement.c
+++ b/cubrid_statement.c
@@ -39,6 +39,7 @@
 #include "php_pdo_cubrid.h"
 #include "php_pdo_cubrid_int.h"
 #include <cas_cci.h>
+#include <broker_cas_error.h>
 
 /************************************************************************
 * PRIVATE DEFINITIONS

--- a/cubrid_statement7.c
+++ b/cubrid_statement7.c
@@ -39,6 +39,7 @@
 #include "php_pdo_cubrid.h"
 #include "php_pdo_cubrid_int.h"
 #include <cas_cci.h>
+#include <broker_cas_error.h>
 
 /************************************************************************
 * PRIVATE DEFINITIONS


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24271

Purpose
modify build environment because changed CCI driver repo environment.

Implementation
- modify file about build. (cmake, and 32bit not support on linux)
- include broker_cas_error.h (in source file)

Remarks
N/A